### PR TITLE
 Remove stray semicolon

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,5 +28,5 @@ fn generate(src_path: &Path, dst_path: &Path) {
     for word in src.lines() {
         write!(dst, "\"{}\",\n", &word.unwrap()).unwrap();
     }
-    write!(dst, "];\n").unwrap();
+    write!(dst, "]\n").unwrap();
 }


### PR DESCRIPTION
This semicolon is currently silently ignored, but that may be changing that in the future.

cc rust-lang/rust#64284