### PR TITLE
Upgrade rand crate & cache thread local rng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ name = "names"
 path = "src/lib.rs"
 
 [dependencies]
-rand = "^0.5"
+rand = "^0.7"


### PR DESCRIPTION
This change upgrades the crate to rand version 0.7.x which involves
handling API changes in rand. There is no external API changes to the
`names` crate so this is purely a refactoring exercise.

In the process up upgrading to the new rand APIs, it seemed reasonable
to cache the thread-local random number generator rather than rely on
re-acquiring it potentially 3 times per name generation. This leads to a
slightly larger memory footprint for `Generator`, but only 8 bytes. The
upside is that there should be a slight performance boost.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>