### PR TITLE
fix(build): add `application` as required feature for the `names` binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ version-sync = "0.9.1"
 
 [package.metadata.docs.rs]
 no-default-features = true
+
+[[bin]]
+name = "names"
+required-features = ["application"]


### PR DESCRIPTION
Without this `cargo build --no-default-features` fails, because clap isn't added as dependency, but it still tries to compile `src/bin/names.rs`.