### PR TITLE
Add more naming strategies/formats enum types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,46 @@
 
 ## [Unreleased] - ReleaseDate
 
-## [0.15.0] - 2024-04-23
+## [0.15.0] - 2024-05-01
 
 > **Breaking Change Upgrade Note For Library Users**
 >
-> Due to the addition of additional naming strategies
+> Due to the addition of additional naming strategies. You now need to pass `true` or `false` to the `Generator::new()` method.
+> 
+> ```rust
+> <!-- No Numbering -->
+> Generator::new(ADJECTIVES, NOUNS, naming, false)
+> 
+> <!-- Numbering -->
+> Generator::new(ADJECTIVES, NOUNS, naming, true)
+> ```
+ 
+- New naming strategies types added to complment `Name:Plain` and `Name::Numbered`. The new namging stratgies are as followed:
+
+  - Name::Plain **adjective-noun**
+  - Name::Numbered  **adjective-noun-number**
+  - Name::TitleCase **Adjective Noun**
+  - Name::CamelCase **adjectiveNoun**
+  - Name::ClassCase **AdjectiveNoun**
+  - Name::KebabCase **adjective-noun**
+  - Name::TrainCase **Adjective-Noun**
+  - Name::TableCase **adjective-noun**
+  - Name::SnakeCase **adjective_noun**
+  - Name::PascalCase **AdjectiveNoun**
+  - Name::SentenceCase **Adjective noun**
+  - Name::ScreamingSnakeCase **Adjective_Noun**
+
 
 ### Changed
 
 - upgrade to `regex` 1.10.4
 - added `Inflector` 0.11.4, used with the naming strategy `to_*_case()` logic.
+
+## [0.14.0] - 2022-06-28
+
+### Changed
+
+- upgrade to `regex` 1.5.6
 
 ## [0.13.0] - 2022-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 ## [Unreleased] - ReleaseDate
 
-## [0.14.0] - 2022-06-28
+## [0.15.0] - 2024-04-23
+
+> **Breaking Change Upgrade Note For Library Users**
+>
+> Due to the addition of additional naming strategies
 
 ### Changed
 
-- upgrade to `regex` 1.5.6
+- upgrade to `regex` 1.10.4
+- added `Inflector` 0.11.4, used with the naming strategy `to_*_case()` logic.
 
 ## [0.13.0] - 2022-03-05
 
@@ -77,13 +82,9 @@ The initial release.
 <!-- next-url -->
 
 [unreleased]: https://github.com/fnichol/names/compare/v0.14.0...HEAD
-
 [0.14.0]: https://github.com/fnichol/names/compare/v0.13.0...v0.14.0
-
 [0.13.0]: https://github.com/fnichol/names/compare/v0.12.0...v0.13.0
-
 [0.12.0]: https://github.com/fnichol/names/compare/v0.11.0...v0.12.0
-
 [0.11.0]: https://github.com/fnichol/names/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/fnichol/names/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/fnichol/names/compare/f852f53...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,25 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,16 +163,18 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "names"
-version = "0.14.1-dev"
+version = "0.15.0-dev"
 dependencies = [
+ "Inflector",
  "clap",
  "rand",
+ "regex",
  "version-sync",
 ]
 
@@ -263,18 +284,32 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "names"
-version = "0.14.1-dev"
+version = "0.15.0-dev"
 authors = ["Fletcher Nichol <fnichol@nichol.ca>"]
 edition = "2018"
 license = "MIT"
@@ -24,11 +24,20 @@ default = ["application"]
 application = ["clap"]
 
 [dependencies]
+Inflector = "0.11.4"
 clap = { version = "3.1.5", optional = true, features = ["derive"] }
 rand = "0.8.4"
 
 [dev-dependencies]
+regex = "1.10.4"
 version-sync = "0.9.1"
 
 [package.metadata.docs.rs]
 no-default-features = true
+
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ adding `names` to your dependencies in your project's `Cargo.toml` file:
 
 ```toml
 [dependencies]
-names = { version = "0.14.0", default-features = false }
+names = { version = "0.15.0-dev", default-features = false }
 ```
 
 ### Examples
@@ -232,6 +232,7 @@ use names::{Generator, Name};
 let mut generator = Generator::with_naming(Name::Numbered);
 println!("Your project is: {}", generator.next().unwrap());
 // #=> "Your project is: pushy-pencil-5602"
+
 ```
 
 #### Example: with custom dictionaries
@@ -245,9 +246,24 @@ use names::{Generator, Name};
 
 let adjectives = &["imaginary"];
 let nouns = &["roll"];
-let mut generator = Generator::new(adjectives, nouns, Name::default());
+let mut generator = Generator::new(adjectives, nouns, Name::default(), false);
 
 assert_eq!("imaginary-roll", generator.next().unwrap());
+```
+
+#### Example: with custom dictionaries and custom naming strategy
+
+As above, if you would like to use a custom naming convenetion. You can supply a
+strategy:
+
+```rust
+use names::{Generator, Name};
+
+let adjectives = &["true"];
+let nouns = &["truth"];
+let mut generator = Generator::new(adjectives, nouns, Name::CamelCase, false);
+
+assert_eq!("trueTruth", generator.next().unwrap());
 ```
 
 ## CI Status

--- a/README.tpl
+++ b/README.tpl
@@ -67,7 +67,7 @@ If you're ever confused, at least there's help:
 
 ```console
 > names --help
-names 0.11.0
+names 0.15.0
 Fletcher Nichol <fnichol@nichol.ca>
 
 A random name generator with results like "delirious-pail"
@@ -79,9 +79,23 @@ ARGS:
     <AMOUNT>    Number of names to generate [default: 1]
 
 FLAGS:
-    -h, --help       Prints help information
-    -n, --number     Adds a random number to the name(s)
-    -V, --version    Prints version information
+    -h, --help                  Prints help information
+    -n, --number                Adds a random number to the name(s)
+    -s, --strategy <STRATEGY>   Use a different naming strategy
+                                  - Plain* [adjective-noun]
+                                  - Numbered [adjective-noun-number]
+                                  - TitleCase [Adjective Noun]
+                                  - CamelCase [adjectiveNoun]
+                                  - ClassCase [AdjectiveNoun]
+                                  - KebabCase [adjective-noun]
+                                  - TrainCase [Adjective-Noun]
+                                  - TableCase [adjective-noun]
+                                  - SnakeCase [adjective_noun]
+                                  - PascalCase [AdjectiveNoun]
+                                  - SentenceCase [Adjective noun]
+                                  - ScreamingSnakeCase [Adjective_Noun]
+                                 * [default: Plain]
+    -V, --version               Prints version information
 ```
 
 ### Installation

--- a/src/bin/names.rs
+++ b/src/bin/names.rs
@@ -3,7 +3,13 @@ use names::Generator;
 fn main() {
     let args = cli::parse();
 
-    Generator::with_naming(args.naming())
+    let generated = if args.number {
+        Generator::with_numbers(args.naming())
+    } else {
+        Generator::with_naming(args.naming())
+    };
+
+    generated
         .take(args.amount)
         .for_each(|name| println!("{}", name));
 }
@@ -11,6 +17,7 @@ fn main() {
 mod cli {
     use clap::Parser;
     use names::Name;
+    use std::str::FromStr;
 
     const AUTHOR: &str = concat!(env!("CARGO_PKG_AUTHORS"), "\n\n");
     const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -27,18 +34,31 @@ mod cli {
         #[clap(short, long)]
         pub(crate) number: bool,
 
+        /// Use a different naming strategy
+        ///  - Plain* [adjective-noun]
+        ///  - Numbered [adjective-noun-number]
+        ///  - TitleCase [Adjective Noun]
+        ///  - CamelCase [adjectiveNoun]
+        ///  - ClassCase [AdjectiveNoun]
+        ///  - KebabCase [adjective-noun]
+        ///  - TrainCase [Adjective-Noun]
+        ///  - TableCase [adjective-noun]
+        ///  - SnakeCase [adjective_noun]
+        ///  - PascalCase [AdjectiveNoun]
+        ///  - SentenceCase [Adjective noun]
+        ///  - ScreamingSnakeCase [Adjective_Noun]
+        ///*
+        #[clap(short, long, default_value = "Plain", verbatim_doc_comment)]
+        pub(crate) strategy: String,
+
         /// Number of names to generate
-        #[clap(default_value = "1", rename_all = "screaming_snake_case")]
+        #[clap(default_value = "1")]
         pub(crate) amount: usize,
     }
 
     impl Args {
         pub(crate) fn naming(&self) -> Name {
-            if self.number {
-                Name::Numbered
-            } else {
-                Name::default()
-            }
+            Name::from_str(&self.strategy).unwrap()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,30 +72,30 @@ pub const NOUNS: &[&str] = &include!(concat!(env!("OUT_DIR"), "/nouns.rs"));
 /// A naming strategy for the `Generator`
 #[derive(Debug, PartialEq, Default)]
 pub enum Name {
-    /// This represents a Title cased naming strategy in the form of `"AdjectiveNoun"`
+    /// This represents a Title cased naming strategy in the form of `"adjective-noun"`
     Plain,
-    /// This represents a Title cased naming strategy in the form of `"AdjectiveNoun"`
+    /// This represents a Title cased naming strategy in the form of `"adjective-noun-number"`
     Numbered,
-    /// This represents a Title cased naming strategy in the form of `"AdjectiveNoun"`
+    /// This represents a Title cased naming strategy in the form of `"Adjective Noun"`
     TitleCase,
     /// This represents a Camel cased naming strategy in the form of `"adjectiveNoun"`
     CamelCase,
-    /// This represents a Class cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Class cased naming strategy in the form of `"AdjectiveNoun"`
     ClassCase,
-    /// This represents a Kebab cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Kebab cased naming strategy in the form of `"adjective-noun"`
     #[default]
     KebabCase,
-    /// This represents a Train cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Train cased naming strategy in the form of `"Adjective-Noun"`
     TrainCase,
-    /// This represents a Screaming Snake cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Screaming Snake cased naming strategy in the form of `"Adjective_Noun"`
     ScreamingSnakeCase,
-    /// This represents a Table cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Table cased naming strategy in the form of `"adjective-noun"`
     TableCase,
-    /// This represents a Sentence cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Sentence cased naming strategy in the form of `"Adjective noun"`
     SentenceCase,
-    /// This represents a Snake cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Snake cased naming strategy in the form of `"adjective_noun"`
     SnakeCase,
-    /// This represents a Pascal cased naming strategy in the form of `"adjectiveNoun"`
+    /// This represents a Pascal cased naming strategy in the form of `"AdjectiveNoun"`
     PascalCase,
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,0 +1,256 @@
+#[cfg(test)]
+mod tests {
+    use names::{Generator, Name};
+    use regex::Regex;
+
+    #[test]
+    fn plain_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::Plain, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)-(?P<noun>[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn plain_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::Numbered, true);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)-(?P<noun>[a-z]+)-?(?P<number>\d+)?").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn title_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::TitleCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)\s(?P<noun>[A-Z]{1}[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn titled_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::TitleCase, true);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(
+            r"^(?P<adjective>[A-Z]{1}[a-z]+)\s(?P<noun>[A-Z]{1}[a-z]+)\s?(?P<number>\d+)?",
+        )
+        .unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn camel_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::CamelCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)(?P<noun>[A-Z]{1}[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn camel_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::CamelCase, true);
+
+        let generated = generator.next().unwrap();
+        let re =
+            Regex::new(r"^(?P<adjective>[a-z]+)(?P<noun>[A-Z]{1}[a-z]+)(?P<number>\d+)?").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn class_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::ClassCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)(?P<noun>[A-Z]{1}[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn class_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::ClassCase, true);
+
+        let generated = generator.next().unwrap();
+        let re =
+            Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)(?P<noun>[A-Z]{1}[a-z]+)(?P<number>\d+)?")
+                .unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn kebab_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::KebabCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)-(?P<noun>[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn kebab_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::KebabCase, true);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)-(?P<noun>[a-z]+)-?(?P<number>\d+)?").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn train_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::TrainCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)-(?P<noun>[A-Z]{1}[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("True-Truth", generator.next().unwrap());
+    }
+
+    #[test]
+    fn train_numbred_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::TrainCase, true);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(
+            r"^(?P<adjective>[A-Z]{1}[a-z]+)-(?P<noun>[A-Z]{1}[a-z]+)-?(?P<number>\d+)?",
+        )
+        .unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("True-Truth", generator.next().unwrap());
+    }
+
+    #[test]
+    fn screaming_snake_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::ScreamingSnakeCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[A-Z]+)_(?P<noun>[A-Z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("TRUE_TRUTH", generator.next().unwrap());
+    }
+
+    #[test]
+    fn screaming_snake_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::ScreamingSnakeCase, true);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[A-Z]+)_(?P<noun>[A-Z]+)_?(?P<number>\d+)?").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("TRUE_TRUTH", generator.next().unwrap());
+    }
+
+    #[test]
+    fn table_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::TableCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)_(?P<noun>[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("true_truths", generator.next().unwrap());
+    }
+
+    #[test]
+    fn table_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::TableCase, true);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)_(?P<noun>[a-z]+)_?(?P<number>\d+)?").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("true_truths", generator.next().unwrap());
+    }
+
+    #[test]
+    fn sentence_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::SentenceCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)\s(?P<noun>[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("True truth", generator.next().unwrap());
+    }
+
+    #[test]
+    fn sentence_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::SentenceCase, true);
+
+        let generated = generator.next().unwrap();
+        println!("{}", &generated);
+        let re = Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)\s(?P<noun>[a-z]+)(?P<number>\d+)?")
+            .unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn snake_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::SnakeCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)_(?P<noun>[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("true_truth", generator.next().unwrap());
+    }
+
+    #[test]
+    fn snake_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::SnakeCase, true);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[a-z]+)_(?P<noun>[a-z]+)_?(?P<number>\d+)?").unwrap();
+
+        assert!(re.is_match(&generated));
+
+        // assert_eq!("true_truth", generator.next().unwrap());
+    }
+
+    #[test]
+    fn pascal_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::PascalCase, false);
+
+        let generated = generator.next().unwrap();
+        let re = Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)(?P<noun>[A-Z]{1}[a-z]+)").unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+
+    #[test]
+    fn pascal_numbered_case() {
+        let mut generator = Generator::new(&["true"], &["truth"], Name::PascalCase, true);
+
+        let generated = generator.next().unwrap();
+        let re =
+            Regex::new(r"^(?P<adjective>[A-Z]{1}[a-z]+)(?P<noun>[A-Z]{1}[a-z]+)(?P<number>\d+)")
+                .unwrap();
+
+        assert!(re.is_match(&generated));
+    }
+}


### PR DESCRIPTION
 HI 👋,
 
Please excuse the uninvited PR, but I thought to share just in case someone else found this useful. Please let me know your thoughts on including, and ill be happy to adapt. 😄 

I needed the format of the generated names to be slightly different. To allow this, I adapted your code to include functionality from Inflector`0.11.4` which manifests itself as new `Name` enum types in addition to `Name::Plain` and `Name::Numbered`. Specifically: 

  - TitleCase  - **Adjective Noun**
  - CamelCase - **adjectiveNoun**
  - ClassCase - **AdjectiveNoun**
  - KebabCase - **adjective-noun**
  - TrainCase - **Adjective-Noun**
  - TableCase - **adjective-noun**
  - SnakeCase - **adjective_noun**
  - PascalCase - **AdjectiveNoun**
  - SentenceCase - **Adjective noun**
  - ScreamingSnakeCase - **Adjective_Noun**

### Change Log
- Added new functionality to `src/lib.rs`, new `Name` types
- Updated `CHANGELOG.md` with notes on new naming strategy functionality
- Added `tests/lib.rs` for naming strategy testing
- Added and Updated `READMD.md` and `README.tpl` with notes on new functionality with examples.
- Updated `bin/names.rs` to reflect breaking changes to `Generator::new` together with additional CLI `-s`/`--strategy` switch logic.
- Updated regex to `1.10.4`
- Added `[profile.release]` section to `Cargo.toml`
- Some typos... probably 